### PR TITLE
Fixes #321 email for some-skjema (patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3457,9 +3457,9 @@
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.5.tgz",
-      "integrity": "sha512-XMoPKjSpXbkeJ7ZZ9icLnJMTY5Mc1kZbCakHquaFsXPpyWOwK0TK6CODO+0ca54UoM9LKOxyUNnoVZRl8TeaAg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",

--- a/pages/api/some/registrerSomeAktivist.js
+++ b/pages/api/some/registrerSomeAktivist.js
@@ -22,7 +22,8 @@ async function registrerAktivist (payload) {
       fornavn: payload.fornavn,
       etternavn: payload.etternavn,
       postnummer: payload.postnummer,
-      telefonnummer: payload.telefonnummer
+      telefonnummer: payload.telefonnummer,
+      email: payload.email
     }
     console.log('klar til å registrere SoMeAktivist')
     console.log(JSON.stringify(aktivistData, null, 2))

--- a/pages/some/skjema.js
+++ b/pages/some/skjema.js
@@ -49,6 +49,10 @@ function Skjema ({ setSuccess }) {
         <input type='text' name='telefonnummer' id='telefonnummer' autoComplete='tel' required className='block w-full shadow-sm py-3 px-4 placeholder-gray-500 focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md' placeholder='Telefonnummer' />
       </div>
       <div>
+        <label htmlFor='email' className='sr-only'>E-post</label>
+        <input type='email' name='email' id='email' autoComplete='email' required className='block w-full shadow-sm py-3 px-4 placeholder-gray-500 focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md' placeholder='E-post' />
+      </div>
+      <div>
         <Button
           type='submit'
           loading={loading}


### PR DESCRIPTION
Kan merges inn når backend er klar for å ta imot `email` som felt fra /some skjemaet